### PR TITLE
Bumps gulp-notify dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "gulp-livereload": "^2.1.1",
     "gulp-minify-css": "^0.3.7",
     "gulp-mocha": "^1.1.0",
-    "gulp-notify": "^1.5.0",
+    "gulp-notify": "^1.8.0",
     "gulp-rev": "^1.1.0",
     "gulp-sourcemaps": "^1.1.4",
     "gulp-template": "^1.0.1",


### PR DESCRIPTION
Bumps gulp-notify. Adds support for native windows 8 and 7.
