### PR TITLE
Removes ending stream on notifyError

### DIFF
--- a/tasks/config.js
+++ b/tasks/config.js
@@ -63,7 +63,6 @@ c.notifyError = function notifyError (description) {
       title: description + " error",
       message: "<%= error.message %>"
     }).apply(this, args);
-    this.emit('end'); // Keep gulp from hanging on this task
   };
 };
 


### PR DESCRIPTION
There isn't any need to end the stream any more. `gulp-notify` does this by it self.
There might be need to bump gulp-notify dependency
